### PR TITLE
Add instructions to README.md to remove .git and reinit git

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ features:
 
 ## Installation
 1. clone the repo
-2. `cd speedrail && bundle` (installs dependencies)
-3. `rails g rename:into new_app_name` (then `cd ../new_app_name` to refresh)
-4. remove `gem 'rename'` from Gemfile, then `bin/setup` to create DB
-5. `bundle exec figaro install`
-6. `cp config/application-sample.yml config/application.yml` (put ENV vars here)
+1. `cd speedrail && bundle` (installs dependencies)
+1. `rails g rename:into new_app_name` (then `cd ../new_app_name` to refresh)
+1. remove `gem 'rename'` from Gemfile, then `bin/setup` to create DB
+1. `bundle exec figaro install`
+1. `cp config/application-sample.yml config/application.yml` (put ENV vars here)
+1. `rm -rf .git` to remove git references to this repo
+1. `git init` to reinitialize git 
 
 ## Development
 ```sh

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ features:
 1. remove `gem 'rename'` from Gemfile, then `bin/setup` to create DB
 1. `bundle exec figaro install`
 1. `cp config/application-sample.yml config/application.yml` (put ENV vars here)
-1. `rm -rf .git` to remove git references to this repo
-1. `git init` to reinitialize git 
+1. `rm -rf .git && git init && git add . && git commit -m 'first commit'` to remove git references to this repo and reinitialize git 
 
 ## Development
 ```sh


### PR DESCRIPTION
It might be good to add a step to the README for users who clone the repo to rm `.git` and re-init git for their own repo. 

I also changed the steps all to 1 since ordered lists in that format [will automagically number themselves](https://www.markdownguide.org/basic-syntax/#ordered-lists)