### PR TITLE
Use color primary everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,13 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# Ignore application configuration
+/config/application.yml
+
+# JetBrains IDE (RubyMine) specifics
+.idea/.gitignore
+.idea/misc.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/vcs.xml

--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,6 @@
 /app/assets/builds/*
 !/app/assets/builds/.keep
 
-# Ignore application configuration
-/config/application.yml
-
 # JetBrains IDE (RubyMine) specifics
 .idea/.gitignore
 .idea/misc.xml

--- a/app/views/account/index.html.erb
+++ b/app/views/account/index.html.erb
@@ -10,7 +10,7 @@
           Billing Status: <%= red_green_message(current_user.paying_customer?, 'Active', 'Inactive') %><br>
         </div>
         <div class="flex-shrink">
-          <%= link_to 'Manage >>', billing_portal_path, class: "font-medium text-indigo-500" %>
+          <%= link_to 'Manage >>', billing_portal_path, class: "font-medium text-primary-500" %>
         </div>
       </div>
 
@@ -27,10 +27,10 @@
             <input type="password" autocomplete="new-password" name="user[password]" id="user_password" class="block w-full border-0 p-0 text-gray-900 placeholder-gray-500 focus:ring-0 sm:text-sm">
           </div>
 
-          <button type="submit" data-turbo="false" class="mt-4 group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+          <button type="submit" data-turbo="false" class="mt-4 group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
             <span class="absolute left-0 inset-y-0 flex items-center pl-3">
               <!-- Heroicon name: solid/lock-closed -->
-              <svg class="h-5 w-5 text-indigo-500 group-hover:text-indigo-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="white" aria-hidden="true">
+              <svg class="h-5 w-5 text-primary-500 group-hover:text-primary-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="white" aria-hidden="true">
                 <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd"></path>
               </svg>
             </span>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -42,7 +42,7 @@
                   <%= user.paying_customer? %>
                 </td>
                 <td class="px-6 py-4 whitespace-wrap text-sm text-gray-500">
-                  <%= link_to 'edit', edit_admin_user_path(id: user.id), class: 'text-indigo-500' %>
+                  <%= link_to 'edit', edit_admin_user_path(id: user.id), class: 'text-primary-500' %>
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                   <%= link_to new_admin_impersonation_path(user_id: user.id) do %>

--- a/app/views/admin/users/_profile.html.erb
+++ b/app/views/admin/users/_profile.html.erb
@@ -12,7 +12,7 @@
   </div>
 
   <div class="mt-6">
-    <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary hover:bg-primary-hover-700 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo transition duration-150 ease-in-out">
+    <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary-600 hover:bg-primary-hover-700 focus:outline-none focus:border-primary-700 focus:shadow-outline-primary transition duration-150 ease-in-out">
       Update
     </button>
   </div>

--- a/app/views/admin/users/_profile.html.erb
+++ b/app/views/admin/users/_profile.html.erb
@@ -12,7 +12,7 @@
   </div>
 
   <div class="mt-6">
-    <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary-600 hover:bg-primary-hover-700 focus:outline-none focus:border-primary-700 focus:shadow-outline-primary transition duration-150 ease-in-out">
+    <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:border-primary-700 focus:shadow-outline-primary transition duration-150 ease-in-out">
       Update
     </button>
   </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -10,7 +10,8 @@
       </div>
 
       <div class="mt-6">
-        <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary hover:bg-primary-hover focus:outline-none transition duration-150 ease-in-out">
+        <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none transition duration-150 ease-in-out">
+        <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none transition duration-150 ease-in-out">
           <span class="absolute left-0 inset-y-0 flex items-center pl-3">
             <svg class="h-5 w-5 transition ease-in-out duration-150" fill="white" viewBox="0 0 20 20">
               <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd" />

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,7 +14,7 @@
       </div>
 
       <div class="mt-6">
-        <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary hover:bg-primary-hover focus:outline-none transition duration-150 ease-in-out">
+        <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none transition duration-150 ease-in-out">
           <span class="absolute left-0 inset-y-0 flex items-center pl-3">
             <svg class="h-5 w-5 transition ease-in-out duration-150" fill="white" viewBox="0 0 20 20">
               <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd" />

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -26,7 +26,7 @@
       </div>
 
       <div class="mt-6">
-        <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary hover:bg-primary-hover focus:outline-none transition duration-150 ease-in-out">
+        <button type="submit" data-turbo="false" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none transition duration-150 ease-in-out">
           <span class="absolute left-0 inset-y-0 flex items-center pl-3">
             <svg class="h-5 w-5 transition ease-in-out duration-150" fill="white" viewBox="0 0 20 20">
               <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd" />

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -11,7 +11,7 @@
             <!-- <span class="block text-sm font-semibold uppercase tracking-wide text-gray-500 sm:text-base lg:text-sm xl:text-base">Coming soon</span> -->
             <span class="mt-1 block text-4xl tracking-tight font-extrabold sm:text-5xl xl:text-6xl">
               <span class="block text-gray-900">A great tagline</span>
-              <span class="block text-indigo-600">with emphasis</span>
+              <span class="block text-primary-600">with emphasis</span>
             </span>
           </h1>
           <p class="mt-3 text-base text-gray-500 sm:mt-5 sm:text-xl lg:text-lg xl:text-xl">
@@ -23,8 +23,8 @@
             </p>
             <form action="<%= new_user_registration_path %>" method="GET" class="mt-3 sm:flex">
               <label for="email" class="sr-only">Email</label>
-              <input type="email" name="email" id="email" class="block w-full py-3 text-base rounded-md placeholder-gray-500 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:flex-1 border-gray-300" placeholder="Enter your email">
-              <button type="submit" class="mt-3 w-full px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-gray-800 shadow-sm hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:flex-shrink-0 sm:inline-flex sm:items-center sm:w-auto">
+              <input type="email" name="email" id="email" class="block w-full py-3 text-base rounded-md placeholder-gray-500 shadow-sm focus:ring-primary-500 focus:border-primary-500 sm:flex-1 border-gray-300" placeholder="Enter your email">
+              <button type="submit" class="mt-3 w-full px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-gray-800 shadow-sm hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 sm:mt-0 sm:ml-3 sm:flex-shrink-0 sm:inline-flex sm:items-center sm:w-auto">
                 Start Free
               </button>
             </form>
@@ -45,10 +45,10 @@
             <rect x="118" width="404" height="784" fill="url(#4f4f415c-a0e9-44c2-9601-6ded5a34a13e)" />
           </svg>
           <div class="relative mx-auto w-full rounded-lg shadow-lg lg:max-w-md">
-            <button type="button" class="relative block w-full bg-white rounded-lg overflow-hidden focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            <button type="button" class="relative block w-full bg-white rounded-lg overflow-hidden focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
               <img class="w-full" src="https://images.unsplash.com/photo-1556740758-90de374c12ad?ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80" alt="">
               <div class="absolute inset-0 w-full h-full flex items-center justify-center" aria-hidden="true">
-                <svg class="h-20 w-20 text-indigo-500" fill="white" viewBox="0 0 84 84">
+                <svg class="h-20 w-20 text-primary-500" fill="white" viewBox="0 0 84 84">
                   <circle opacity="0.9" cx="42" cy="42" r="42" fill="white" />
                   <path d="M55.5039 40.3359L37.1094 28.0729C35.7803 27.1869 34 28.1396 34 29.737V54.263C34 55.8604 35.7803 56.8131 37.1094 55.9271L55.5038 43.6641C56.6913 42.8725 56.6913 41.1275 55.5039 40.3359Z" />
                 </svg>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -11,7 +11,7 @@
 
   <h2 class="mt-6 text-center text-3xl leading-9 font-extrabold text-gray-900">Consent</h2>
 
-  <p class="mt-2 text-gray-600">By using our website, you hereby consent to our Privacy Policy and agree to its <%= link_to 'Terms of Service', terms_path, class: "font-medium text-indigo-500" %>.</p>
+  <p class="mt-2 text-gray-600">By using our website, you hereby consent to our Privacy Policy and agree to its <%= link_to 'Terms of Service', terms_path, class: "font-medium text-primary-500" %>.</p>
 
   <h2 class="mt-6 text-center text-3xl leading-9 font-extrabold text-gray-900">Information we collect</h2>
 

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -43,7 +43,7 @@
 
   <h2 class="mt-6 text-center text-3xl leading-9 font-extrabold text-gray-900">8. Your Privacy</h2>
 
-  <p class="mt-2 text-gray-600">Please read our <%= link_to 'Privacy Policy', privacy_path, class: "font-medium text-indigo-500" %>.</p>
+  <p class="mt-2 text-gray-600">Please read our <%= link_to 'Privacy Policy', privacy_path, class: "font-medium text-primary-500" %>.</p>
 
   <h2 class="mt-6 text-center text-3xl leading-9 font-extrabold text-gray-900">9. Governing Law</h2>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,7 +5,7 @@
       <%= link_to logo_path do %>
         <%= image_tag "avatar.png",  style: "max-height: 42px" %>
       <% end %>
-      <span class="font-semibold text-xl tracking-tight"><%= ENV['COMPANY_NAME'] %></span>
+      <span class="font-semibold text-xl tracking-tight text-primary-600"><%= ENV['COMPANY_NAME'] %></span>
     </div>
     <div class="block sm:hidden">
       <button class="navbar-burger flex items-center px-3 py-2 border rounded text-white border-white hover:text-white hover:border-white" data-action="click->header#toggleMobileNav">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,7 +25,7 @@
         <% else %>
           <%= link_to 'Contact', "mailto:#{ENV['ADMIN_EMAIL']}", target: '_blank', class: nav_link_classes('contact')  %>
           <%= link_to 'Login', new_user_session_path, class: nav_link_classes('login') %>
-          <%= link_to 'Signup', new_user_registration_path, class: 'ml-8 whitespace-nowrap text-base font-medium inline-flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700' %>
+          <%= link_to 'Signup', new_user_registration_path, class: 'ml-8 whitespace-nowrap text-base font-medium inline-flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-white bg-primary-600 hover:bg-primary-700' %>
         <% end %>
       </div>
     </div>

--- a/app/views/subscribe/index.html.erb
+++ b/app/views/subscribe/index.html.erb
@@ -8,13 +8,13 @@
 <p class="mt-12 text-center">Click here to choose a plan and activate your account.</p>
 <div class="mt-2 justify-center text-center">
   <div class="text-center inline-flex rounded-md shadow">
-    <button onclick="beginSubscription()" type="submit" class="items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700">
+    <button onclick="beginSubscription()" type="submit" class="items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700">
       Start Free
     </button>
   </div>
   <div class="mt-2 text-center">
     <!-- bind this element to a live chat tool or mailto address -->
-    <a id="open-live-chat" href="#" onclick="return false;" class="font-medium text-indigo-300 hover:text-indigo-500">Still have questions?</a>
+    <a id="open-live-chat" href="#" onclick="return false;" class="font-medium text-primary-300 hover:text-primary-500">Still have questions?</a>
   </div>
 </div>
 

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,4 +1,6 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
+const colors = require('tailwindcss/colors')
+
 
 module.exports = {
   content: [
@@ -11,12 +13,9 @@ module.exports = {
       fontFamily: {
         sans: ['Inter var', ...defaultTheme.fontFamily.sans]
       },
-      colors: { // custom color palette for branding
-        'primary': 'rgb(79, 70, 229)',
-        'primary-hover': {
-          '700': '#a4411c',
-          '500': '#EA9A72'
-        }
+      // custom color palette for branding, see https://tailwindcss.com/docs/customizing-colors
+      colors: {
+        primary: colors.lime
       }
     },
   },


### PR DESCRIPTION
This PR removes (hopefully) all element level color definitions for our "primary" color.

Prior to this we defined a hex code primary color in our tailwind css, but still had many references to `text-indigo` throughout the codebase.

I switched the hex code to be tailwind's default color definitions, and updated all references to indigo to `text-primary`. A new user starting their own project with Speedrail should be able to switch that primary color and have it updated everywhere, making the zero to first launch even faster.