### PR TITLE
Set Devise to use "Paranoid" mode

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -90,7 +90,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.


### PR DESCRIPTION
Setting Devise to use "paranoid" mode prevents the library from enumerating users. 

Prior to enabling paranoid mode a malicious user could use the "forgot password" page to fish for user emails. With paranoid mode off, entering an email of a user who does not exists returns a form validation error (Email not found,) but works for an email in the system.

With this setting set to true we'll ALWAYS make it seem that a forgot password emails is sent, limiting the amount of private date we expose to the end user.

In development letter_opener will still pop open a new tab so we'll know if password resets are behaving as they should.